### PR TITLE
Makefile: Use QEMU built from Tock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,12 @@
 export PATH := $(PATH):$(HOME)/tools/gnu-elf-rv32imac-compact/bin
 export PATH := $(PWD)/elf2tab/target/debug:$(PATH)
 
-qemu=qemu-6.1.0
 example=libtock-c/examples/c_hello
 tbf=build/rv32imac/rv32imac.tbf
 elf2tab=elf2tab/target/debug/elf2tab
 
-run: $(example)/$(tbf) tock $(qemu)/build/qemu-system-riscv32
-	cd tock/boards/hifive1 && qemu=$(PWD)/$(qemu)/build/qemu-system-riscv32 APP=$(PWD)/$(example)/$(tbf) make qemu-app
+run: $(example)/$(tbf) tock qemu
+	cd tock/boards/hifive1 && QEMU=../../tools/qemu/build/qemu-system-riscv32 APP=$(PWD)/$(example)/$(tbf) make qemu-app
 
 relocate: tock
 	cd tock && patch -p1 < ../change-app-load-addr.diff
@@ -40,7 +39,7 @@ llvm-project:
 $(HOME)/tools/gnu-elf-rv32imac-compact/bin/riscv32-unknown-elf-clang: llvm-project
 	mkdir -p llvm-project/build && cd llvm-project/build && cmake ../llvm -G Ninja -DCMAKE_BUILD_TYPE="Release" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ENABLE_LLD=True -DLLVM_TARGETS_TO_BUILD="RISCV" -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_INSTALL_PREFIX=$(HOME)/tools/gnu-elf-rv32imac-compact -DCLANG_LINKS_TO_CREATE=riscv32-unknown-elf-clang && ninja install
 
-$(qemu)/build/qemu-system-riscv32:
-	curl https://download.qemu.org/$(qemu).tar.xz --output $(qemu).tar.xz && tar xf $(qemu).tar.xz && cd $(qemu) && ./configure --target-list=riscv32-softmmu --disable-linux-io-uring --disable-libdaxctl && make
+qemu:
+	cd tock && CI=y make ci-setup-qemu
 
 .PHONY: run relocate


### PR DESCRIPTION
Instead of manually building QEMU let's instead have the Tock CI do it
for us.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>